### PR TITLE
Add change-password feature

### DIFF
--- a/RJMS/Views/Profile/ChangePassword.cshtml
+++ b/RJMS/Views/Profile/ChangePassword.cshtml
@@ -1,0 +1,159 @@
+@model vn.edu.fpt.dto.ChangePasswordViewModel
+@{
+    ViewData["Title"] = "Đổi mật khẩu";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+
+    var userName = Context.Session.GetString("UserName") ?? "";
+    var userEmail = Context.Session.GetString("UserEmail") ?? "";
+    var firstName = userName.Split(' ').FirstOrDefault() ?? "U";
+}
+
+<div class="container py-4">
+    <div class="row g-4">
+
+        <!-- Sidebar -->
+        <div class="col-lg-3">
+            <div class="card border-0 shadow-sm rounded-3">
+                <div class="card-body p-4 text-center border-bottom bg-light">
+                    <div class="rounded-circle bg-secondary d-inline-flex align-items-center justify-content-center mb-2"
+                         style="width:60px;height:60px;">
+                        <span class="fw-bold fs-3 text-white">
+                            @(firstName.Length > 0 ? firstName.Substring(0,1).ToUpper() : "U")
+                        </span>
+                    </div>
+                    <p class="mb-0 fw-semibold">@userName</p>
+                    <small class="text-muted" style="word-break:break-all">@userEmail</small>
+                </div>
+            </div>
+        </div>
+
+        <!-- Main content -->
+        <div class="col-lg-9">
+            <div class="card border-0 shadow-sm rounded-3">
+                <div class="card-header bg-white border-bottom px-4 py-3">
+                    <h5 class="mb-0 fw-bold">Đổi mật khẩu</h5>
+                    <small class="text-muted">Mật khẩu mới phải có ít nhất 8 ký tự, gồm chữ hoa, chữ số và ký tự đặc biệt.</small>
+                </div>
+                <div class="card-body p-4">
+                    <form asp-action="ChangePassword" method="post" id="changePasswordForm" novalidate style="max-width:480px">
+                        @Html.AntiForgeryToken()
+
+                        <div asp-validation-summary="ModelOnly" class="alert alert-danger py-2 small" style="display:@(ViewData.ModelState.IsValid ? "none" : "block")"></div>
+
+                        <div class="mb-3">
+                            <label asp-for="CurrentPassword" class="form-label fw-semibold">
+                                Mật khẩu hiện tại <span class="text-danger">*</span>
+                            </label>
+                            <div class="input-group">
+                                <input asp-for="CurrentPassword" class="form-control" type="password"
+                                       id="currentPw" placeholder="Nhập mật khẩu hiện tại" autocomplete="current-password" />
+                                <button class="btn btn-outline-secondary" type="button" onclick="togglePw('currentPw',this)">Hiện</button>
+                            </div>
+                            <div class="text-danger small mt-1" style="min-height:18px">
+                                <span asp-validation-for="CurrentPassword"></span>
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label asp-for="NewPassword" class="form-label fw-semibold">
+                                Mật khẩu mới <span class="text-danger">*</span>
+                            </label>
+                            <div class="input-group">
+                                <input asp-for="NewPassword" class="form-control" type="password"
+                                       id="newPw" placeholder="Nhập mật khẩu mới" autocomplete="new-password" />
+                                <button class="btn btn-outline-secondary" type="button" onclick="togglePw('newPw',this)">Hiện</button>
+                            </div>
+                            <div id="newPwErr" class="text-danger small mt-1" style="min-height:18px">
+                                <span asp-validation-for="NewPassword"></span>
+                            </div>
+                        </div>
+
+                        <div class="mb-4">
+                            <label asp-for="ConfirmPassword" class="form-label fw-semibold">
+                                Xác nhận mật khẩu mới <span class="text-danger">*</span>
+                            </label>
+                            <div class="input-group">
+                                <input asp-for="ConfirmPassword" class="form-control" type="password"
+                                       id="confirmPw" placeholder="Nhập lại mật khẩu mới" autocomplete="new-password" />
+                                <button class="btn btn-outline-secondary" type="button" onclick="togglePw('confirmPw',this)">Hiện</button>
+                            </div>
+                            <div id="confirmPwErr" class="text-danger small mt-1" style="min-height:18px">
+                                <span asp-validation-for="ConfirmPassword"></span>
+                            </div>
+                        </div>
+
+                        <div class="d-flex gap-2">
+                            <button type="submit" class="btn btn-success px-4">Đổi mật khẩu</button>
+                            <a asp-controller="Home" asp-action="Index" class="btn btn-outline-secondary px-4">Huỷ</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+<script>
+(function () {
+    function togglePw(inputId, btn) {
+        var el = document.getElementById(inputId);
+        if (!el) return;
+        var isText = el.type === 'text';
+        el.type = isText ? 'password' : 'text';
+        btn.textContent = isText ? 'Hiện' : 'Ẩn';
+    }
+    window.togglePw = togglePw;
+
+    var newPwInput = document.getElementById('newPw');
+    var confirmPwInput = document.getElementById('confirmPw');
+    var newPwErr = document.getElementById('newPwErr');
+    var confirmPwErr = document.getElementById('confirmPwErr');
+
+    function isValidPassword(v) {
+        return v.length >= 8 && /[A-Z]/.test(v) && /[0-9]/.test(v) && /[^a-zA-Z0-9]/.test(v);
+    }
+
+    function validateNewPw() {
+        var v = newPwInput ? newPwInput.value : '';
+        if (!v) { if(newPwErr) newPwErr.textContent = ''; return true; }
+        var ok = isValidPassword(v);
+        if (newPwErr) newPwErr.textContent = ok ? '' : 'Mật khẩu phải có ít nhất 8 ký tự, gồm chữ hoa, chữ số và ký tự đặc biệt.';
+        if (newPwInput) {
+            if (ok) newPwInput.classList.remove('is-invalid'); else newPwInput.classList.add('is-invalid');
+        }
+        return ok;
+    }
+
+    function validateConfirmPw() {
+        var v = confirmPwInput ? confirmPwInput.value : '';
+        var nv = newPwInput ? newPwInput.value : '';
+        if (!v) { if(confirmPwErr) confirmPwErr.textContent = ''; return true; }
+        var ok = v === nv;
+        if (confirmPwErr) confirmPwErr.textContent = ok ? '' : 'Mật khẩu xác nhận không khớp.';
+        if (confirmPwInput) {
+            if (ok) confirmPwInput.classList.remove('is-invalid'); else confirmPwInput.classList.add('is-invalid');
+        }
+        return ok;
+    }
+
+    if (newPwInput) {
+        newPwInput.addEventListener('input', function () { validateNewPw(); validateConfirmPw(); });
+        newPwInput.addEventListener('blur', validateNewPw);
+    }
+    if (confirmPwInput) {
+        confirmPwInput.addEventListener('input', validateConfirmPw);
+        confirmPwInput.addEventListener('blur', validateConfirmPw);
+    }
+
+    var form = document.getElementById('changePasswordForm');
+    if (form) {
+        form.addEventListener('submit', function (e) {
+            var ok1 = validateNewPw();
+            var ok2 = validateConfirmPw();
+            if (!ok1 || !ok2) e.preventDefault();
+        });
+    }
+})();
+</script>
+}

--- a/RJMS/vn/edu/fpt/Models/DTOs/ChangePasswordViewModel.cs
+++ b/RJMS/vn/edu/fpt/Models/DTOs/ChangePasswordViewModel.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace vn.edu.fpt.dto
+{
+    public class ChangePasswordViewModel
+    {
+        [Required(ErrorMessage = "Vui lòng nhập mật khẩu hiện tại")]
+        [DataType(DataType.Password)]
+        [Display(Name = "Mật khẩu hiện tại")]
+        public string CurrentPassword { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Vui lòng nhập mật khẩu mới")]
+        [DataType(DataType.Password)]
+        [MinLength(8, ErrorMessage = "Mật khẩu phải có ít nhất 8 ký tự")]
+        [Display(Name = "Mật khẩu mới")]
+        public string NewPassword { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Vui lòng xác nhận mật khẩu mới")]
+        [DataType(DataType.Password)]
+        [Compare("NewPassword", ErrorMessage = "Mật khẩu xác nhận không khớp")]
+        [Display(Name = "Xác nhận mật khẩu mới")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+    }
+}

--- a/RJMS/vn/edu/fpt/Repository/IProfileRepository.cs
+++ b/RJMS/vn/edu/fpt/Repository/IProfileRepository.cs
@@ -1,9 +1,12 @@
 using RJMS.Vn.Edu.Fpt.Model.DTOs;
+using RJMS.vn.edu.fpt.Models;
 
 namespace RJMS.Vn.Edu.Fpt.Repository
 {
     public interface IProfileRepository
     {
         Task<UserProfileDTO?> GetProfileByUserIdAsync(string userId);
+        Task<User?> GetUserByIdAsync(int userId);
+        Task<bool> UpdateUserPasswordAsync(int userId, string newPasswordHash);
     }
 }

--- a/RJMS/vn/edu/fpt/Repository/ProfileRepository.cs
+++ b/RJMS/vn/edu/fpt/Repository/ProfileRepository.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using RJMS.Vn.Edu.Fpt.Model.DTOs;
 using RJMS.vn.edu.fpt.Models;
+using vn.edu.fpt.Utilities;
 
 namespace RJMS.Vn.Edu.Fpt.Repository
 {
@@ -59,6 +60,28 @@ namespace RJMS.Vn.Edu.Fpt.Repository
                 CreatedAt = candidate.CreatedAt ?? DateTime.MinValue,
                 UpdatedAt = null,
             };
+        }
+
+        public async Task<User?> GetUserByIdAsync(int userId)
+        {
+            return await _context.Users
+                .AsNoTracking()
+                .FirstOrDefaultAsync(u => u.Id == userId);
+        }
+
+        public async Task<bool> UpdateUserPasswordAsync(int userId, string newPasswordHash)
+        {
+            var user = await _context.Users.FirstOrDefaultAsync(u => u.Id == userId);
+            if (user == null)
+            {
+                return false;
+            }
+
+            user.PasswordHash = newPasswordHash;
+            user.UpdatedAt = DateTimeHelper.NowVietnam;
+
+            await _context.SaveChangesAsync();
+            return true;
         }
     }
 }

--- a/RJMS/vn/edu/fpt/Service/IProfileService.cs
+++ b/RJMS/vn/edu/fpt/Service/IProfileService.cs
@@ -5,5 +5,6 @@ namespace RJMS.Vn.Edu.Fpt.Service
     public interface IProfileService
     {
         Task<UserProfileDTO?> GetPersonalProfileAsync(string userId);
+        Task<(bool Success, string Message)> ChangePasswordAsync(int userId, string currentPassword, string newPassword);
     }
 }

--- a/RJMS/vn/edu/fpt/Service/ProfileService.cs
+++ b/RJMS/vn/edu/fpt/Service/ProfileService.cs
@@ -1,5 +1,6 @@
 using RJMS.Vn.Edu.Fpt.Model.DTOs;
 using RJMS.Vn.Edu.Fpt.Repository;
+using BCrypt.Net;
 
 namespace RJMS.Vn.Edu.Fpt.Service
 {
@@ -16,6 +17,55 @@ namespace RJMS.Vn.Edu.Fpt.Service
         {
             var profile = await _profileRepository.GetProfileByUserIdAsync(userId);
             return profile;
+        }
+
+        public async Task<(bool Success, string Message)> ChangePasswordAsync(int userId, string currentPassword, string newPassword)
+        {
+            // Validate new password format
+            if (string.IsNullOrWhiteSpace(newPassword) || newPassword.Length < 8)
+            {
+                return (false, "Mật khẩu mới phải có ít nhất 8 ký tự");
+            }
+
+            if (!newPassword.Any(char.IsUpper))
+            {
+                return (false, "Mật khẩu mới phải có ít nhất một chữ hoa");
+            }
+
+            if (!newPassword.Any(char.IsDigit))
+            {
+                return (false, "Mật khẩu mới phải có ít nhất một chữ số");
+            }
+
+            if (newPassword.All(char.IsLetterOrDigit))
+            {
+                return (false, "Mật khẩu mới phải có ít nhất một ký tự đặc biệt");
+            }
+
+            // Get user
+            var user = await _profileRepository.GetUserByIdAsync(userId);
+            if (user == null)
+            {
+                return (false, "Người dùng không tồn tại");
+            }
+
+            // Verify current password
+            if (!BCrypt.Net.BCrypt.Verify(currentPassword, user.PasswordHash))
+            {
+                return (false, "Mật khẩu hiện tại không đúng");
+            }
+
+            // Hash new password
+            var newPasswordHash = BCrypt.Net.BCrypt.HashPassword(newPassword);
+
+            // Update password
+            var updated = await _profileRepository.UpdateUserPasswordAsync(userId, newPasswordHash);
+            if (!updated)
+            {
+                return (false, "Không thể cập nhật mật khẩu");
+            }
+
+            return (true, "Đổi mật khẩu thành công");
         }
     }
 }

--- a/RJMS/vn/edu/fpt/controller/ProfileController.cs
+++ b/RJMS/vn/edu/fpt/controller/ProfileController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using RJMS.Vn.Edu.Fpt.Model.DTOs;
 using RJMS.Vn.Edu.Fpt.Service;
+using vn.edu.fpt.dto;
 
 namespace RJMS.Vn.Edu.Fpt.Controllers
 {
@@ -31,6 +32,49 @@ namespace RJMS.Vn.Edu.Fpt.Controllers
             }
 
             return View("PersonalProfile", profile);
+        }
+
+        [HttpGet]
+        public IActionResult ChangePassword()
+        {
+            // Check if user is logged in
+            var userIdStr = HttpContext.Request.Cookies["UserId"];
+            if (string.IsNullOrWhiteSpace(userIdStr))
+            {
+                TempData["ErrorToast"] = "Vui lòng đăng nhập để đổi mật khẩu";
+                return RedirectToAction("Login", "Auth");
+            }
+
+            return View(new ChangePasswordViewModel());
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> ChangePassword(ChangePasswordViewModel model)
+        {
+            // Check if user is logged in
+            var userIdStr = HttpContext.Request.Cookies["UserId"];
+            if (string.IsNullOrWhiteSpace(userIdStr) || !int.TryParse(userIdStr, out var userId))
+            {
+                TempData["ErrorToast"] = "Vui lòng đăng nhập để đổi mật khẩu";
+                return RedirectToAction("Login", "Auth");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            var (success, message) = await _profileService.ChangePasswordAsync(userId, model.CurrentPassword, model.NewPassword);
+
+            if (success)
+            {
+                TempData["SuccessToast"] = message;
+                return RedirectToAction("ChangePassword");
+            }
+
+            ModelState.AddModelError(string.Empty, message);
+            return View(model);
         }
     }
 }


### PR DESCRIPTION
Add full change-password flow: new ChangePassword view with client-side validation and password visibility toggles, and a ChangePasswordViewModel for server-side validation. Extend repository with GetUserByIdAsync and UpdateUserPasswordAsync (updates UpdatedAt via DateTimeHelper.NowVietnam). Add IProfileService.ChangePasswordAsync and implement it in ProfileService to validate password rules, verify current password, hash new password with BCrypt, and persist the change. Add controller GET/POST actions to show the form and handle submissions, including auth checks (UserId cookie), ModelState handling, and TempData success/error messages.